### PR TITLE
Enhance: babel-preset-es2015 is deprecated

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    "es2015",
+    "env",
     "react"
   ],
   "plugins": [

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "babel-jest": "^22.4.1",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
-    "babel-preset-es2015": "^6.24.1",
+    "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "catalog": "^3.4.0",
     "chai": "^4.1.2",


### PR DESCRIPTION
Use babel-preset-env instead
Ref: https://babeljs.io/env/